### PR TITLE
feat: Enable recording for anonymous user.

### DIFF
--- a/app/models/video_models.py
+++ b/app/models/video_models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from pydantic import BaseModel
-from sqlalchemy import Column, Enum, String, DateTime, ForeignKey, Integer
+from sqlalchemy import Column, Enum, String, DateTime, ForeignKey
 from sqlalchemy.orm import relationship
 
 from app.database import Base
@@ -11,9 +11,9 @@ class Video(Base):
     __tablename__ = "videos"
 
     id: str = Column(String, primary_key=True, unique=True, nullable=False)
-    user_id: int = Column(
-        Integer,
-        ForeignKey("users.id", ondelete="CASCADE"),
+    username: str = Column(
+        String,
+        ForeignKey("users.username", ondelete="CASCADE"),
         nullable=False,
     )
     created_date: DateTime = Column(DateTime, default=datetime.utcnow)
@@ -35,7 +35,7 @@ class Video(Base):
 
 
 class VideoBlob(BaseModel):
-    user_id: int
+    username: str
     video_id: str
     blob_index: int
     blob_object: bytes

--- a/app/services/services.py
+++ b/app/services/services.py
@@ -15,9 +15,8 @@ from app.settings import VIDEO_DIR, DEEPGRAM_API_KEY
 
 
 def process_video(
-    video_id: int,
+    video_id: str,
     file_location: str,
-    filename: str,
     username: str,
 ):
     """
@@ -26,7 +25,7 @@ def process_video(
     Args:
         video_id (int): The ID of the video.
         file_location (str): The location of the video file.
-        filename (str): The name of the video file.
+        video_id (str): The name of the video file.
 
     Raises:
         HTTPException: If an error occurs.
@@ -38,17 +37,17 @@ def process_video(
     video = db.query(Video).filter(Video.id == video_id).first()
 
     # Generate compressed and thumbnail filenames
-    audio = f"audio_{filename}.mp3"
-    audio_location = os.path.join(VIDEO_DIR, username, filename, audio)
+    audio = f"audio_{video_id}.mp3"
+    audio_location = os.path.join(VIDEO_DIR, username, video_id, audio)
     audio_location = os.path.abspath(audio_location)
-    trans = f"transcript_{filename}.json"
-    transcript_location = os.path.join(VIDEO_DIR, username, filename, trans)
+    trans = f"transcript_{video_id}.json"
+    transcript_location = os.path.join(VIDEO_DIR, username, video_id, trans)
     transcript_location = os.path.abspath(transcript_location)
-    comp = f"compressed_{filename}.mp4"
-    compressed_location = os.path.join(VIDEO_DIR, username, filename, comp)
+    comp = f"compressed_{video_id}.mp4"
+    compressed_location = os.path.join(VIDEO_DIR, username, video_id, comp)
     compressed_location = os.path.abspath(compressed_location)
-    thumb = f"thumbnail_{filename}.jpg"
-    thumbnail_location = os.path.join(VIDEO_DIR, username, filename, thumb)
+    thumb = f"thumbnail_{video_id}.jpg"
+    thumbnail_location = os.path.join(VIDEO_DIR, username, video_id, thumb)
     thumbnail_location = os.path.abspath(thumbnail_location)
 
     try:

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -11,7 +11,16 @@ USERNAME = "cofucan"
 FILENAME = "videoA"  # This should be unique for each video.
 
 
-def get_video_id(username):
+def get_video_id(username: str) -> str:
+    """
+    Get the video ID for a user.
+
+    Args:
+        username (str): The username
+
+    Returns:
+        str: Th video id
+    """
     data = {"username": username}
 
     headers = {"Content-Type": "application/json"}
@@ -25,7 +34,16 @@ def get_video_id(username):
     return res_data["video_id"]
 
 
-def send_blob(video_id, blob, blob_id, is_last):
+def send_blob(video_id: str, blob: bytes, blob_id: int, is_last: bool):
+    """
+    Sends the video in blobs
+
+    Args:
+        video_id (str): The id of the video
+        blob (bytes): The blob in bytes
+        blob_id (int): The index of the blob
+        is_last (bool): Whether the blob is the last one
+    """
     data = {
         "username": USERNAME,
         "video_id": video_id,
@@ -41,6 +59,7 @@ def send_blob(video_id, blob, blob_id, is_last):
 
 
 def main():
+    """ The main function """
     video_id = get_video_id("user10")
     with open(VIDEO_FILE_PATH, "rb") as f:
         blob_id = 1

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -7,12 +7,12 @@ VIDEO_FILE_PATH = "/home/cofucan/Videos/test_rec.mkv"
 GET_VIDIO_ID_URL = "http://127.0.0.1:8000/srce/api/start-recording/"
 ENDPOINT_URL = "http://127.0.0.1:8000/srce/api/upload-blob/"
 BLOB_SIZE = 1 * 1024 * 1024  # 1MB by default. Adjust as needed.
-USER_ID = "cofucan"
+USERNAME = "cofucan"
 FILENAME = "videoA"  # This should be unique for each video.
 
 
-def get_video_id(user_id):
-    data = {"user_id": user_id}
+def get_video_id(username):
+    data = {"username": username}
 
     headers = {"Content-Type": "application/json"}
     response = requests.post(
@@ -27,7 +27,7 @@ def get_video_id(user_id):
 
 def send_blob(video_id, blob, blob_id, is_last):
     data = {
-        "user_id": 1,
+        "username": USERNAME,
         "video_id": video_id,
         "blob_index": blob_id,
         "blob_object": base64.b64encode(blob).decode("utf-8"),
@@ -41,7 +41,7 @@ def send_blob(video_id, blob, blob_id, is_last):
 
 
 def main():
-    video_id = get_video_id("1")
+    video_id = get_video_id("user10")
     with open(VIDEO_FILE_PATH, "rb") as f:
         blob_id = 1
         while True:


### PR DESCRIPTION
Enable recording for anonymous users
​
## Description
* The endpoint for sending video blobs no longer requires a user to be created.
* The caller can send a unique username to be used and an account will be created using it.
* Changed all uses of `user_id` to ` username` for simplicity
​
## Related Issue (Link to linear ticket)
None
​
## Motivation and Context
It is needed so that a user can use the extension without needing to create an account
​
## How Has This Been Tested?
* The endpoint for starting a recording was tested using a username that already exists (after using the user signup endpoint) and it world
* It was then tested using a username that was not present in the database. In this case, the a new anonymous user is created using this new username, which will be used to serve the user who is using the extension without being logged in.
​
## Screenshots (if appropriate - Postman, etc):
![image](https://github.com/hngx-org/helpmeout-api/assets/66657791/b7228766-466a-4df5-b714-4b3fa3d94df3)

​
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
