### PR TITLE
Empty recording

### DIFF
--- a/app/routes/video_routes.py
+++ b/app/routes/video_routes.py
@@ -365,11 +365,12 @@ def delete_video(video_id: str, db: Session = Depends(get_db)):
     """
     video = db.query(Video).filter(Video.id == video_id).first()
     if video:
-        os.remove(video.original_location)
-        if os.path.exists(video.thumbnail_location):
-            os.remove(video.thumbnail_location)
-        if os.path.exists(video.compressed_location):
-            os.remove(video.compressed_location)
+        if os.path.exists(str(video.original_location)):
+            os.remove(str(video.original_location))
+        if os.path.exists(str(video.thumbnail_location)):
+            os.remove(str(video.thumbnail_location))
+        if os.path.exists(str(video.compressed_location)):
+            os.remove(str(video.compressed_location))
 
         db.delete(video)
         db.commit()

--- a/app/services/services.py
+++ b/app/services/services.py
@@ -266,6 +266,10 @@ def merge_blobs(username: str, video_id: str) -> str:
         key=lambda x: int(os.path.splitext(os.path.basename(x))[0]),
     )
 
+    # Check if no blobs were found
+    if not blob_files:
+        return None
+
     # Merge the blobs
     merged_video_path = os.path.join(temp_video_dir, f"{video_id}.mp4")
     with open(merged_video_path, "wb") as merged_file:


### PR DESCRIPTION
## Description

This Pull Request addresses the following changes:

- Handling cases where no blob is sent.
- Retrieving a video when recording is terminated.
- Fixing a bug by type-casting the file path in the delete route.

## Motivation and Context
Experienced a bug when trying to delete a video, and also got error with no specific response when trying to stream and empty video or one that stopped sending halfway.


## Changes Made

- Added handling for cases where no blob is sent.
- Implemented logic to retrieve a video when recording is terminated.
- Fixed a bug by type-casting the file path in the delete route.
- made adjustment to the route for transcript and thumbnail to make them concise 

## Related Issue
N/A


## How Has This Been Tested?
- Tested the changes locally by simulating various scenarios during video upload and deletion.
- Ran existing test to ensure that was still intact

## Screenshots (if appropriate)
![Screenshot_20231010-080025](https://github.com/hngx-org/helpmeout-api/assets/84413505/56ae4662-16c7-4c96-9d3c-4ddf4c423235)
![Screenshot_20231010-080118](https://github.com/hngx-org/helpmeout-api/assets/84413505/380d26a1-8936-49e6-805d-b4cd6ab96cda)
![Screenshot_20231010-080137](https://github.com/hngx-org/helpmeout-api/assets/84413505/07043d90-5573-4084-8260-cf0f402416c8)
![Screenshot_20231010-081448](https://github.com/hngx-org/helpmeout-api/assets/84413505/8e87eb5f-7cb7-44f2-9974-0bf174679016)
![Screenshot_20231010-081608](https://github.com/hngx-org/helpmeout-api/assets/84413505/a064a59c-e93a-4597-a658-c2d5c5d391ef)


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
