### PR TITLE
Feat ✨:  Added an endpoint to download video locally 

### DIFF
--- a/app/routes/video_routes.py
+++ b/app/routes/video_routes.py
@@ -284,10 +284,10 @@ def stream_video(video_id: str, db: Session = Depends(get_db)):
 
     return FileResponse(video.original_location, media_type="video/mp4")
 
-@router.get("/download/{video_id}.mp4")
+@router.get("/download/{video_id}")
 def download_video(video_id: str, db: Session = Depends(get_db)):
     """
-    Triggers diwnalod of a video by its video ID.
+    Triggers download of a video by its video ID.
 
     Parameters:
         video_id (str): The ID of the video to be streamed.
@@ -295,7 +295,7 @@ def download_video(video_id: str, db: Session = Depends(get_db)):
             result of the get_db function.
 
     Returns:
-        FileResponse: The file response containing the video stream.
+        FileResponse: The file response containing the video file.
 
     Raises:
         HTTPException: If the video is not found.
@@ -314,7 +314,7 @@ def download_video(video_id: str, db: Session = Depends(get_db)):
         db.commit()
         db.close()
 
-    return FileResponse(video.original_location, media_type="video/mp4", filename=video.title+".mp4")
+    return FileResponse(video.original_location, media_type="video/mp4", filename=f"{video.title}.mp4")
 
 @router.get("/transcript/{video_id}.json")
 def get_transcript(video_id: str, db: Session = Depends(get_db)):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
​
## Description
<!--- Describe your changes in detail -->
I added an extra endpoint to allow users downlaod videos to their local device. It is exactly same as streaming a video but here i specified filetype and this makes FastAPI send us the video as a diwnlaodsble rather than just rendering it as we did before
​
## Related Issue (Link to linear ticket)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
[ Linear Ticket ](https://linear.app/zuri-project-backend/issue/HEL-1/create-video-disbursing-endpoint>, this is kinda unrelated to my ticket which i have already fulfilled.
​
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
​I am adding this endpont because it is needed in cases where the user would want to download the video locally than just play it in the browser.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have tested this locally on my PC and mobile decide so when i try to access the url, download begins automatically 
​
## Screenshots (if appropriate - Postman, etc):
https://github.com/hngx-org/helpmeout-api/assets/84413505/5613709a-58b8-476b-9226-24eff73f776c


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
