### PR TITLE
fix: Make email field to actually be optional

### DIFF
--- a/app/models/user_models.py
+++ b/app/models/user_models.py
@@ -40,7 +40,7 @@ class UserRequest(BaseModel):
     """The user request model"""
 
     username: str
-    email: Optional[str]
+    email: Optional[str] = None
 
 
 class UserAuthentication(UserRequest):


### PR DESCRIPTION
Make email field to be optional during signup and login
​
## Description
* Added a default value of `None` to email attribute in the schema so it is optional
​
## Related Issue (Link to linear ticket)
None specifically
​
## Motivation and Context
Because it was preventing signup and login from the frontend
​
## How Has This Been Tested?
* It was tested using the test script and also using Swagger docs.
​
## Screenshots (if appropriate - Postman, etc):
​
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
