### PR TITLE
remove srce-api prefix from routes

### DIFF
--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -30,7 +30,7 @@ from app.settings import (
     GOOGLE_REDIRECT_URL,
 )
 
-BASE_URL = "/srce/api"
+BASE_URL = ""
 
 auth_router = APIRouter(prefix=BASE_URL)
 
@@ -165,7 +165,7 @@ async def login_user(
         raise HTTPException(status_code=401, detail="Invalid Password.")
 
 
-@auth_router.post("/request_otp/")
+@auth_router.post("/request-otp/")
 async def request_otp(
     username: str, db: Session = Depends(get_db)
 ) -> OtpResponse:

--- a/app/routes/video_routes.py
+++ b/app/routes/video_routes.py
@@ -26,7 +26,7 @@ from app.services.services import (
     is_owner,
 )
 
-video_router = APIRouter(prefix="/srce/api")
+video_router = APIRouter(prefix="")
 
 
 @video_router.post("/start-recording/")

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -8,8 +8,8 @@ import requests
 # Configuration
 # VIDEO_FILE_PATH = "/home/cofucan/Videos/test_rec.mkv"
 VIDEO_FILE_PATH = "/home/destinedcodes/video2.mp4"
-LOCAL_URL = "http://127.0.0.1:8000/srce/api"
-REMOTE_URL = "https://helpmeout.cofucan.tech/srce/api"
+LOCAL_URL = "http://127.0.0.1:8000"
+REMOTE_URL = "https://api.helpmeout.tech"
 
 if sys.argv[1] == "--local":
     URL = LOCAL_URL


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
​
## Description
<!--- Describe your changes in detail -->
I removed the /scre/api prefix from all api routes and updated the request-otp route to use hypen in place of underscore
​
## Related Issue (Link to linear ticket)
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
None
​
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
​Since were using a custom domain with api subdomain, there no need for having /srce which represented screenrecord and /api as part of routes any longer. Previous domain had conflicts so we used that prefix to identify the routes for this project.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
​all routes still work as expected, FE will be required to make changes too

## Screenshots (if appropriate - Postman, etc):
![Screenshot_20231020-153000](https://github.com/hngx-org/helpmeout-api/assets/84413505/be437eda-1098-42e8-b3a2-9bc2cd59f27a)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated tests to cover my changes.
- [x] All new and existing tests passed.
