### PR TITLE
Mimetype

### DIFF
--- a/app/models/video_models.py
+++ b/app/models/video_models.py
@@ -1,16 +1,25 @@
-""" The video models """""
+""" The video models """ ""
 from datetime import datetime
 from typing import Optional
 
 from pydantic import BaseModel
-from sqlalchemy import Column, Enum, String, DateTime, ForeignKey, Boolean, Float
+from sqlalchemy import (
+    Column,
+    Enum,
+    String,
+    DateTime,
+    ForeignKey,
+    Boolean,
+    Float,
+)
 from sqlalchemy.orm import relationship
 
 from app.database import Base
 
 
 class Video(Base):
-    """ The video model """
+    """The video model"""
+
     __tablename__ = "videos"
 
     id: str = Column(String, primary_key=True, unique=True, nullable=False)
@@ -42,7 +51,8 @@ class Video(Base):
 
 
 class VideoBlob(BaseModel):
-    """ The video blob model """
+    """The video blob model"""
+
     username: str
     video_id: str
     blob_index: int

--- a/app/routes/video_routes.py
+++ b/app/routes/video_routes.py
@@ -2,8 +2,11 @@
 import base64
 import datetime
 import os
-
+from fastapi import Query
+from sqlalchemy import desc
 import math
+
+
 from fastapi import (
     APIRouter,
     BackgroundTasks,
@@ -11,11 +14,9 @@ from fastapi import (
     HTTPException,
     Request,
 )
-from fastapi import Query
 from fastapi.responses import FileResponse, RedirectResponse
-from sqlalchemy import desc
-from sqlalchemy import func
 from sqlalchemy.orm import Session
+from sqlalchemy import func
 
 from app.database import get_db
 from app.models.user_models import User
@@ -194,14 +195,16 @@ def get_videos(
         db (Session): The database session.
 
     Returns:
-        dict: A dictionary containing the list of Video objects for the requested page, along with pagination information.
+        dict: A dictionary containing the list of Video objects for the
+        requested page, along with pagination information.
     """
     items_per_page: int = 6
 
     # Calculate the offset to skip items on previous pages
     offset = (page - 1) * items_per_page
 
-    # Query the database with pagination and sorting by creation date in descending order
+    # Query the database with pagination and sorting by creation date in
+    # descending order
     videos = (
         db.query(Video)
         .filter(func.lower(Video.username) == func.lower(username))
@@ -255,7 +258,9 @@ def search_videos(
     db: Session = Depends(get_db),
 ):
     """
-    Search for videos associated with the given username based on a search query in the video title with pagination support and sorting from most recent to least recent.
+    Search for videos associated with the given username based on a search
+    query in the video title with pagination support and sorting from most
+    recent to least recent.
 
     Parameters:
         username (str): The username for which to search for videos.
@@ -265,7 +270,8 @@ def search_videos(
         db (Session): The database session.
 
     Returns:
-        dict: A dictionary containing the list of Video objects for the requested page, along with pagination information.
+        dict: A dictionary containing the list of Video objects for the
+        requested page, along with pagination information.
     """
 
     items_per_page: int = 6
@@ -273,7 +279,8 @@ def search_videos(
     # Calculate the offset to skip items on previous pages
     offset = (page - 1) * items_per_page
 
-    # Query the database with pagination and sorting by creation date in descending order
+    # Query the database with pagination and sorting by creation date in
+    # descending order
     videos = (
         db.query(Video)
         .filter(func.lower(Video.username) == func.lower(username))

--- a/app/routes/video_routes.py
+++ b/app/routes/video_routes.py
@@ -26,6 +26,7 @@ from app.services.services import (
     hash_password,
     is_owner,
 )
+from app.settings import VIDEO_MIME_TYPE
 
 video_router = APIRouter(prefix="")
 
@@ -293,7 +294,7 @@ def stream_video(video_id: str, db: Session = Depends(get_db)):
     if video.status == "processing":
         raise HTTPException(status_code=404, detail="Video not ready.")
 
-    return FileResponse(video.original_location, media_type="video/mp4")
+    return FileResponse(video.original_location, media_type=f"video/{VIDEO_MIME_TYPE}")
 
 
 @video_router.get("/download/{video_id}")
@@ -328,8 +329,8 @@ def download_video(video_id: str, db: Session = Depends(get_db)):
 
     return FileResponse(
         video.original_location,
-        media_type="video/mp4",
-        filename=f"{video.title}.mp4",
+        media_type=f"video/{VIDEO_MIME_TYPE}",
+        filename=f"{video.title}.{VIDEO_MIME_TYPE}",
     )
 
 

--- a/app/routes/video_routes.py
+++ b/app/routes/video_routes.py
@@ -190,8 +190,9 @@ def get_videos(username: str, request: Request, db: Session = Depends(get_db)):
     """
 
     videos = (
-        db.query(Video).filter(func.lower(Video.username)
-                              == func.lower(username)).all()
+        db.query(Video)
+        .filter(func.lower(Video.username) == func.lower(username))
+        .all()
     )
 
     if not videos:

--- a/app/services/services.py
+++ b/app/services/services.py
@@ -66,23 +66,37 @@ def process_video(
     )
 
     try:
-        # Extract audio from the video
-        audio_location = extract_audio(file_location, audio_location, "mp3")
-
         # Get the length of the video
         video_length = get_video_length(file_location)
 
-        # Generate transcript using external API
-        transcript_location = asyncio.run(
-            generate_transcript(
-                audio_location, transcript_location, DEEPGRAM_API_KEY, "json"
+        # Extract audio from the video
+        if not os.path.isfile(f"{audio_location}.mp3"):
+            audio_location = extract_audio(
+                file_location, audio_location, "mp3"
             )
-        )
+        else:
+            audio_location = f"{audio_location}.mp3"
+
+        # Generate transcript using external API
+        if not os.path.isfile(f"{transcript_location}.json"):
+            transcript_location = asyncio.run(
+                generate_transcript(
+                    audio_location,
+                    transcript_location,
+                    DEEPGRAM_API_KEY,
+                    "json",
+                )
+            )
+        else:
+            transcript_location = f"{transcript_location}.json"
 
         # Extract thumbnail from compressed video
-        thumbnail_location = extract_thumbnail(
-            file_location, thumbnail_location, "jpg"
-        )
+        if not os.path.isfile(f"{thumbnail_location}.jpg"):
+            thumbnail_location = extract_thumbnail(
+                file_location, thumbnail_location, "jpg"
+            )
+        else:
+            thumbnail_location = f"{thumbnail_location}.jpg"
 
     except Exception as err:
         # Update the video status to `failed` if an error occurs

--- a/app/services/services.py
+++ b/app/services/services.py
@@ -1,3 +1,4 @@
+""" This module contains helper functions for the application. """
 import asyncio
 import glob
 import json
@@ -156,7 +157,7 @@ def extract_audio(input_path: str, output_path: str, mimetype: str) -> str:
 
 
 def compress_video(
-    input_path: str, output_path: str, extension: str = VIDEO_MIME_TYPE
+    input_path: str, output_path: str, extension: str = "webm"
 ) -> str:
     """
     Compresses a video using ffmpeg.
@@ -329,12 +330,12 @@ def merge_blobs(username: str, video_id: str) -> str | None:
     """
     user_dir = os.path.join(VIDEO_DIR, username)
     user_dir = os.path.abspath(user_dir)
-    temp_video_dir = os.path.join(user_dir, video_id)
-    temp_video_dir = os.path.abspath(temp_video_dir)
+    video_dir = os.path.join(user_dir, video_id)
+    video_dir = os.path.abspath(video_dir)
 
     # List all blob files and sort them by their sequence ID
     blob_files = sorted(
-        glob.glob(os.path.join(temp_video_dir, f"*.{VIDEO_MIME_TYPE}")),
+        glob.glob(os.path.join(video_dir, f"*.{VIDEO_MIME_TYPE}")),
         key=lambda x: int(os.path.splitext(os.path.basename(x))[0]),
     )
 
@@ -343,13 +344,13 @@ def merge_blobs(username: str, video_id: str) -> str | None:
         return None
 
     # Merge the blobs
-    merged_video_path = os.path.join(temp_video_dir, f"{video_id}.{VIDEO_MIME_TYPE}")
-    with open(merged_video_path, "wb") as merged_file:
+    merged_video = os.path.join(video_dir, f"{video_id}.{VIDEO_MIME_TYPE}")
+    with open(merged_video, "wb") as merged_file:
         for blob_file in blob_files:
             with open(blob_file, "rb") as f:
                 merged_file.write(f.read())
 
-    return merged_video_path
+    return merged_video
 
 
 def generate_id() -> str:

--- a/app/services/services.py
+++ b/app/services/services.py
@@ -21,6 +21,7 @@ from app.settings import (
     EMAIL_REGEX,
     PASSWORD_REGEX,
 )
+from app.settings import VIDEO_MIME_TYPE
 
 
 def process_video(
@@ -142,7 +143,7 @@ def extract_audio(input_path: str, output_path: str, mimetype: str) -> str:
 
 
 def compress_video(
-    input_path: str, output_path: str, extension: str = "mp4"
+    input_path: str, output_path: str, extension: str = VIDEO_MIME_TYPE
 ) -> str:
     """
     Compresses a video using ffmpeg.
@@ -294,7 +295,7 @@ def save_blob(
     create_directory(user_dir, video_dir)
 
     # Save the blob
-    blob_filename = f"{blob_index}.mp4"
+    blob_filename = f"{blob_index}.{VIDEO_MIME_TYPE}"
     blob_path = os.path.join(video_dir, blob_filename)
     with open(blob_path, "wb") as f:
         f.write(blob)
@@ -320,7 +321,7 @@ def merge_blobs(username: str, video_id: str) -> str | None:
 
     # List all blob files and sort them by their sequence ID
     blob_files = sorted(
-        glob.glob(os.path.join(temp_video_dir, "*.mp4")),
+        glob.glob(os.path.join(temp_video_dir, f"*.{VIDEO_MIME_TYPE}")),
         key=lambda x: int(os.path.splitext(os.path.basename(x))[0]),
     )
 
@@ -329,7 +330,7 @@ def merge_blobs(username: str, video_id: str) -> str | None:
         return None
 
     # Merge the blobs
-    merged_video_path = os.path.join(temp_video_dir, f"{video_id}.mp4")
+    merged_video_path = os.path.join(temp_video_dir, f"{video_id}.{VIDEO_MIME_TYPE}")
     with open(merged_video_path, "wb") as merged_file:
         for blob_file in blob_files:
             with open(blob_file, "rb") as f:

--- a/app/settings.py
+++ b/app/settings.py
@@ -10,6 +10,7 @@ DB_HOST = "localhost"
 DB_PORT = 3306
 DB_NAME = "helpmeout"
 DB_TYPE = "sqlite"
+VIDEO_MIME_TYPE = "webm"
 MEDIA_DIR = "./media"
 VIDEO_DIR = f"{MEDIA_DIR}/uploads/"
 COMPRESSED_DIR = f"{MEDIA_DIR}/compressed/"

--- a/app/settings.py
+++ b/app/settings.py
@@ -11,6 +11,7 @@ DB_PORT = 3306
 DB_NAME = "helpmeout"
 DB_TYPE = "sqlite"
 VIDEO_MIME_TYPE = "webm"
+AUDIO_MIME_TYPE = "opus"
 MEDIA_DIR = "./media"
 VIDEO_DIR = f"{MEDIA_DIR}/uploads/"
 COMPRESSED_DIR = f"{MEDIA_DIR}/compressed/"


### PR DESCRIPTION
Fixed Mimetype
​
## Description
- Made the `mimetype` for audio and video formats to be a global setting which can be changed easily.
- Changed the video mimetype to `webm`
- Changed the audio mimetype to `opus`
​
## Related Issue (Link to linear ticket)
None specifically
​
## Motivation and Context
It was required because the Chrome extension could not send the data in `mp4` format which was previously specified.
​
## How Has This Been Tested?
- It was tested using the test script to send blobs
​
## Screenshots (if appropriate - Postman, etc):
__A a video's files after using the script__
![image](https://github.com/hngx-org/helpmeout-api/assets/66657791/19b0193c-9d30-4ed3-b598-365034fa863b)

​
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
​
## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
